### PR TITLE
CHORE: bump node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Use the official lightweight Node.js 18 image.
-# https://hub.docker.com/_/node
-FROM node:18-slim
+FROM node:22.18.0-slim
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` to a newer Node.js version. This change ensures the application uses the latest Node.js features and security updates.

Dependency updates:

* Changed the base image from `node:18-slim` to `node:22.18.0-slim` in the `Dockerfile` to upgrade Node.js to version 22.18.0.